### PR TITLE
Fix override_footnotestyle() issues

### DIFF
--- a/public/class-wp-bigfoot-public.php
+++ b/public/class-wp-bigfoot-public.php
@@ -53,7 +53,7 @@ class Wp_Bigfoot_Public {
 		$this->version = $version;
 		add_shortcode('footnote', array($this,'shortcode_footnote') );
 		add_filter( 'the_content', array($this, 'the_content' ), 12 );
-		add_action('wp_footer', array($this, 'override_footnotestyle')); 
+		add_action('wp_head', array($this, 'override_footnotestyle'));
 
 	}
 
@@ -163,20 +163,24 @@ class Wp_Bigfoot_Public {
 	 */
 	public function override_footnotestyle() {
 		$options = get_option( 'wpbf-options');
-		$bg = $options['wpbf-bgcolor'];
-		$fg = $options['wpbf-fgcolor'];
 
-		if ( isset( $bg ) || isset( $fg) )
+		if ( array_key_exists( 'wpbf-bgcolor', $options ) || array_key_exists( 'wpbf-fgcolor', $options ) ):
 		?>
 		<style type="text/css">
+			<?php if ( array_key_exists( 'wpbf-bgcolor', $options ) && !empty( $options['wpbf-bgcolor'] ) ): ?>
 			.bigfoot-footnote__button  {
-				background-color: <?php echo $bg; ?> !important;
+				background-color: <?php echo $options['wpbf-bgcolor']; ?> !important;
 			}
+			<?php endif; ?>
+
+			<?php if ( array_key_exists( 'wpbf-fgcolor', $options ) && !empty( $options['wpbf-fgcolor'] ) ): ?>
 			.bigfoot-footnote__button:after {
-				color: <?php echo $fg; ?> !important;
+				color: <?php echo $options['wpbf-fgcolor']; ?> !important;
 			}
+			<?php endif; ?>
 		</style>
 		<?php
+		endif;
 	}	
 
 }


### PR DESCRIPTION
On a fresh install, without setting colors for wp-bigfoot, the option names `wpbf-bgcolor` and `wpbf-fgcolor` are unknown and generate PHP “undefined index” notices.

<img width="777" alt="Screenshot 2021-12-10 09 28 55" src="https://user-images.githubusercontent.com/368349/145553216-c7fa781a-3e00-4c33-ba54-b1de1cabf1ba.png">

If only one color is set the other CSS statement has no value and this results in an CSS error. This fix only shows a CSS statement if a color is set.

Move the STYLE tag into the HEAD of the HTML via `wp_head` hook.